### PR TITLE
use ssh compression and a ssh-cipher that enables AES-NI

### DIFF
--- a/bscp
+++ b/bscp
@@ -118,7 +118,7 @@ def bscp(local_filename, remote_host, remote_filename, blocksize, hashname):
         blockcount = int((size + blocksize - 1) / blocksize)
 
         remote_command = 'python -c "%s"' % (remote_script,)
-        command = ('ssh', '--', remote_host, remote_command)
+        command = ('ssh', '-C', '-c', 'aes128-gcm@openssh.com', '--', remote_host, remote_command)
         p = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         io = IOCounter(p.stdout, p.stdin)
 


### PR DESCRIPTION
If the transfer rate is limited by
  - network-bandwidth, enable SSH stream compression
  - ssh/sshd cpu load, switch the ssh-cipher to a one that utilizes
    hardware-accelerated crypto (like x86-aes-ni)